### PR TITLE
Get multiple computation statuses at once

### DIFF
--- a/src/main/java/org/gridsuite/computation/error/ComputationBusinessErrorCode.java
+++ b/src/main/java/org/gridsuite/computation/error/ComputationBusinessErrorCode.java
@@ -16,6 +16,7 @@ public enum ComputationBusinessErrorCode implements BusinessErrorCode {
     PARAMETERS_NOT_FOUND("computation.parametersNotFound"),
     INVALID_SORT_FORMAT("computation.invalidSortFormat"),
     INVALID_EXPORT_PARAMS("computation.invalidExportParams"),
+    EMPTY_PARAMS("computation.emptyParams"),
     LIMIT_REDUCTION_CONFIG_ERROR("computation.limitReductionConfigError"),
     RUNNER_ERROR("computation.runnerError");
 

--- a/src/main/java/org/gridsuite/computation/error/ComputationBusinessErrorCode.java
+++ b/src/main/java/org/gridsuite/computation/error/ComputationBusinessErrorCode.java
@@ -16,7 +16,6 @@ public enum ComputationBusinessErrorCode implements BusinessErrorCode {
     PARAMETERS_NOT_FOUND("computation.parametersNotFound"),
     INVALID_SORT_FORMAT("computation.invalidSortFormat"),
     INVALID_EXPORT_PARAMS("computation.invalidExportParams"),
-    EMPTY_PARAMS("computation.emptyParams"),
     LIMIT_REDUCTION_CONFIG_ERROR("computation.limitReductionConfigError"),
     RUNNER_ERROR("computation.runnerError");
 

--- a/src/main/java/org/gridsuite/computation/service/AbstractComputationResultService.java
+++ b/src/main/java/org/gridsuite/computation/service/AbstractComputationResultService.java
@@ -7,6 +7,7 @@
 package org.gridsuite.computation.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -22,6 +23,8 @@ public abstract class AbstractComputationResultService<S> {
     public abstract void deleteAll();
 
     public abstract S findStatus(UUID resultUuid);
+
+    public abstract Map<UUID, S> findStatuses(List<UUID> resultUuids);
 
     // --- Must implement these following methods if a computation server supports s3 storage --- //
     public void saveDebugFileLocation(UUID resultUuid, String debugFilePath) {

--- a/src/main/java/org/gridsuite/computation/service/AbstractComputationResultService.java
+++ b/src/main/java/org/gridsuite/computation/service/AbstractComputationResultService.java
@@ -22,9 +22,7 @@ public abstract class AbstractComputationResultService<S> {
 
     public abstract void deleteAll();
 
-    public S findStatus(UUID resultUuid) {
-        return findStatuses(List.of(resultUuid)).get(resultUuid);
-    }
+    public abstract S findStatus(UUID resultUuid);
 
     public abstract Map<UUID, S> findStatuses(List<UUID> resultUuids);
 

--- a/src/main/java/org/gridsuite/computation/service/AbstractComputationResultService.java
+++ b/src/main/java/org/gridsuite/computation/service/AbstractComputationResultService.java
@@ -22,7 +22,9 @@ public abstract class AbstractComputationResultService<S> {
 
     public abstract void deleteAll();
 
-    public abstract S findStatus(UUID resultUuid);
+    public S findStatus(UUID resultUuid) {
+        return findStatuses(List.of(resultUuid)).get(resultUuid);
+    }
 
     public abstract Map<UUID, S> findStatuses(List<UUID> resultUuids);
 

--- a/src/main/java/org/gridsuite/computation/service/AbstractComputationService.java
+++ b/src/main/java/org/gridsuite/computation/service/AbstractComputationService.java
@@ -9,6 +9,8 @@ package org.gridsuite.computation.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.PowsyblException;
 import lombok.Getter;
+
+import org.gridsuite.computation.error.ComputationException;
 import org.gridsuite.computation.s3.ComputationS3Service;
 import org.gridsuite.computation.s3.S3InputStreamInfos;
 import org.springframework.core.io.InputStreamResource;
@@ -22,9 +24,11 @@ import org.springframework.util.CollectionUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import static org.gridsuite.computation.error.ComputationBusinessErrorCode.EMPTY_PARAMS;
 import static org.gridsuite.computation.s3.ComputationS3Service.S3_SERVICE_NOT_AVAILABLE_MESSAGE;
 
 /**
@@ -99,6 +103,13 @@ public abstract class AbstractComputationService<C extends AbstractComputationRu
 
     public S getStatus(UUID resultUuid) {
         return resultService.findStatus(resultUuid);
+    }
+
+    public Map<UUID, S> getStatuses(List<UUID> resultUuids) {
+        if (resultUuids.isEmpty()) {
+            throw new ComputationException(EMPTY_PARAMS, "Result uuids cannot be empty");
+        }
+        return resultService.findStatuses(resultUuids);
     }
 
     public ResponseEntity<Resource> downloadDebugFile(UUID resultUuid) {

--- a/src/main/java/org/gridsuite/computation/service/AbstractComputationService.java
+++ b/src/main/java/org/gridsuite/computation/service/AbstractComputationService.java
@@ -9,7 +9,6 @@ package org.gridsuite.computation.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.PowsyblException;
 import lombok.Getter;
-
 import org.gridsuite.computation.s3.ComputationS3Service;
 import org.gridsuite.computation.s3.S3InputStreamInfos;
 import org.springframework.core.io.InputStreamResource;
@@ -100,7 +99,7 @@ public abstract class AbstractComputationService<C extends AbstractComputationRu
     }
 
     public S getStatus(UUID resultUuid) {
-        return getStatuses(List.of(resultUuid)).get(resultUuid);
+        return resultService.findStatus(resultUuid);
     }
 
     public Map<UUID, S> getStatuses(List<UUID> resultUuids) {

--- a/src/main/java/org/gridsuite/computation/service/AbstractComputationService.java
+++ b/src/main/java/org/gridsuite/computation/service/AbstractComputationService.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.PowsyblException;
 import lombok.Getter;
 
-import org.gridsuite.computation.error.ComputationException;
 import org.gridsuite.computation.s3.ComputationS3Service;
 import org.gridsuite.computation.s3.S3InputStreamInfos;
 import org.springframework.core.io.InputStreamResource;
@@ -28,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.gridsuite.computation.error.ComputationBusinessErrorCode.EMPTY_PARAMS;
 import static org.gridsuite.computation.s3.ComputationS3Service.S3_SERVICE_NOT_AVAILABLE_MESSAGE;
 
 /**
@@ -102,12 +100,12 @@ public abstract class AbstractComputationService<C extends AbstractComputationRu
     }
 
     public S getStatus(UUID resultUuid) {
-        return resultService.findStatus(resultUuid);
+        return getStatuses(List.of(resultUuid)).get(resultUuid);
     }
 
     public Map<UUID, S> getStatuses(List<UUID> resultUuids) {
-        if (resultUuids.isEmpty()) {
-            throw new ComputationException(EMPTY_PARAMS, "Result uuids cannot be empty");
+        if (CollectionUtils.isEmpty(resultUuids)) {
+            return Map.of();
         }
         return resultService.findStatuses(resultUuids);
     }

--- a/src/test/java/org/gridsuite/computation/ComputationTest.java
+++ b/src/test/java/org/gridsuite/computation/ComputationTest.java
@@ -27,6 +27,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.WithAssertions;
 import org.gridsuite.computation.dto.ReportInfos;
+import org.gridsuite.computation.error.ComputationException;
 import org.gridsuite.computation.error.ComputationRunException;
 import org.gridsuite.computation.s3.ComputationS3Service;
 import org.gridsuite.computation.s3.S3InputStreamInfos;
@@ -61,6 +62,8 @@ import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.gridsuite.computation.s3.ComputationS3Service.S3_DELIMITER;
 import static org.gridsuite.computation.s3.ComputationS3Service.S3_SERVICE_NOT_AVAILABLE_MESSAGE;
@@ -129,6 +132,11 @@ class ComputationTest implements WithAssertions {
         @Override
         public MockComputationStatus findStatus(UUID resultUuid) {
             return mockDBStatus.get(resultUuid);
+        }
+
+        @Override
+        public Map<UUID, MockComputationStatus> findStatuses(List<UUID> resultUuids) {
+            return resultUuids.stream().collect(Collectors.toMap(Function.identity(), mockDBStatus::get));
         }
     }
 
@@ -374,6 +382,25 @@ class ComputationTest implements WithAssertions {
         workerService.consumeCancel().accept(message);
         assertNotNull(resultService.findStatus(RESULT_UUID));
         verify(notificationService.getPublisher(), times(1)).send(eq("publishCancelFailed-out-0"), isA(Message.class));
+    }
+
+    @Test
+    void testGetStatusesReturnsStatuses() {
+        UUID firstResultUuid = UUID.randomUUID();
+        UUID secondResultUuid = UUID.randomUUID();
+        computationService.setStatus(List.of(firstResultUuid), MockComputationStatus.RUNNING);
+        computationService.setStatus(List.of(secondResultUuid), MockComputationStatus.COMPLETED);
+
+        Map<UUID, MockComputationStatus> statuses = computationService.getStatuses(List.of(firstResultUuid, secondResultUuid));
+
+        assertThat(statuses).containsExactlyInAnyOrderEntriesOf(Map.of(firstResultUuid, MockComputationStatus.RUNNING, secondResultUuid, MockComputationStatus.COMPLETED));
+        verify(resultService).findStatuses(List.of(firstResultUuid, secondResultUuid));
+    }
+
+    @Test
+    void testGetStatusesThrowsWhenResultUuidsEmpty() {
+        List<UUID> emptyResultUuids = List.of();
+        assertThrows(ComputationException.class, () -> computationService.getStatuses(emptyResultUuids));
     }
 
     @Test

--- a/src/test/java/org/gridsuite/computation/ComputationTest.java
+++ b/src/test/java/org/gridsuite/computation/ComputationTest.java
@@ -27,7 +27,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.WithAssertions;
 import org.gridsuite.computation.dto.ReportInfos;
-import org.gridsuite.computation.error.ComputationException;
 import org.gridsuite.computation.error.ComputationRunException;
 import org.gridsuite.computation.s3.ComputationS3Service;
 import org.gridsuite.computation.s3.S3InputStreamInfos;
@@ -385,7 +384,7 @@ class ComputationTest implements WithAssertions {
     }
 
     @Test
-    void testGetStatusesReturnsStatuses() {
+    void testGetStatuses() {
         UUID firstResultUuid = UUID.randomUUID();
         UUID secondResultUuid = UUID.randomUUID();
         computationService.setStatus(List.of(firstResultUuid), MockComputationStatus.RUNNING);
@@ -398,9 +397,10 @@ class ComputationTest implements WithAssertions {
     }
 
     @Test
-    void testGetStatusesThrowsWhenResultUuidsEmpty() {
+    void testGetStatusesWithNoResultUuids() {
         List<UUID> emptyResultUuids = List.of();
-        assertThrows(ComputationException.class, () -> computationService.getStatuses(emptyResultUuids));
+        assertThat(computationService.getStatuses(emptyResultUuids)).isEmpty();
+        assertThat(computationService.getStatuses(null)).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/gridsuite/computation/ComputationTest.java
+++ b/src/test/java/org/gridsuite/computation/ComputationTest.java
@@ -133,7 +133,7 @@ class ComputationTest implements WithAssertions {
             return mockDBStatus.get(resultUuid);
         }
 
-        `@Override`
+        @Override
         public Map<UUID, MockComputationStatus> findStatuses(List<UUID> resultUuids) {
             return resultUuids.stream()
                     .filter(mockDBStatus::containsKey)

--- a/src/test/java/org/gridsuite/computation/ComputationTest.java
+++ b/src/test/java/org/gridsuite/computation/ComputationTest.java
@@ -397,6 +397,11 @@ class ComputationTest implements WithAssertions {
 
         assertThat(statuses).containsExactlyInAnyOrderEntriesOf(Map.of(firstResultUuid, MockComputationStatus.RUNNING, secondResultUuid, MockComputationStatus.COMPLETED));
         verify(resultService).findStatuses(List.of(firstResultUuid, secondResultUuid));
+
+        UUID nonExistingResultUuid = UUID.randomUUID();
+        statuses = computationService.getStatuses(List.of(firstResultUuid, secondResultUuid, nonExistingResultUuid));
+        assertThat(statuses).containsExactlyInAnyOrderEntriesOf(Map.of(firstResultUuid, MockComputationStatus.RUNNING, secondResultUuid, MockComputationStatus.COMPLETED));
+        verify(resultService).findStatuses(List.of(firstResultUuid, secondResultUuid, nonExistingResultUuid));
     }
 
     @Test

--- a/src/test/java/org/gridsuite/computation/ComputationTest.java
+++ b/src/test/java/org/gridsuite/computation/ComputationTest.java
@@ -133,9 +133,11 @@ class ComputationTest implements WithAssertions {
             return mockDBStatus.get(resultUuid);
         }
 
-        @Override
+        `@Override`
         public Map<UUID, MockComputationStatus> findStatuses(List<UUID> resultUuids) {
-            return resultUuids.stream().collect(Collectors.toMap(Function.identity(), mockDBStatus::get));
+            return resultUuids.stream()
+                    .filter(mockDBStatus::containsKey)
+                    .collect(Collectors.toMap(Function.identity(), mockDBStatus::get));
         }
     }
 


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
Add `getStatuses` in `AbstractComputationService`
Add `findStatuses` in `AbstractComputationResultService`


